### PR TITLE
Enemy spawners

### DIFF
--- a/Assets/Prefabs/Door.prefab
+++ b/Assets/Prefabs/Door.prefab
@@ -1,0 +1,175 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6595611579766837254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4627542041508179788}
+  m_Layer: 0
+  m_Name: SpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4627542041508179788
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6595611579766837254}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6958219280195143855}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7947190764797059366
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6958219280195143855}
+  - component: {fileID: 1118463207434888155}
+  - component: {fileID: 1839940338735705939}
+  - component: {fileID: 8774339405929696555}
+  - component: {fileID: 6507214777451348784}
+  - component: {fileID: 178196164183485560}
+  m_Layer: 0
+  m_Name: Door
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6958219280195143855
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7947190764797059366}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.43044055, y: 0.6256418, z: 4.7778273}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4627542041508179788}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1118463207434888155
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7947190764797059366}
+  m_Mesh: {fileID: 4300000, guid: 5c1ef6aff58fcec4da97d75a7258c82c, type: 3}
+--- !u!23 &1839940338735705939
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7947190764797059366}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a74066172cf19cd4bacae3c6600a7217, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &8774339405929696555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7947190764797059366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25c12336356bddc48a9f697c2665923b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spawnTransform: {fileID: 4627542041508179788}
+  doorDirection: 0
+  spawnDoor: 0
+  lockedMesh: {fileID: 4300004, guid: 19e0112a50b7fe743b90ae1524a8acdf, type: 3}
+  openMesh: {fileID: 4300000, guid: db8bc3d166184ac4d85181169931b8e5, type: 3}
+--- !u!65 &6507214777451348784
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7947190764797059366}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.5, y: 2.115695, z: 1}
+  m_Center: {x: 0, y: 1, z: 0.5}
+--- !u!114 &178196164183485560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7947190764797059366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac935a605c074b84d9024594d901b1f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gizmoMesh: {fileID: 0}
+  startingSpawn: 0

--- a/Assets/Prefabs/Door.prefab.meta
+++ b/Assets/Prefabs/Door.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8b3ace57969e67e4e99ca8e6d0acfedd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Monster.prefab
+++ b/Assets/Prefabs/Monster.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4261264091733659315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8702590851903923775}
+  - component: {fileID: 2496288242231744031}
+  - component: {fileID: 8765320183250751633}
+  m_Layer: 0
+  m_Name: Monster
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8702590851903923775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4261264091733659315}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.44118, y: 0.5, z: 1.0756893}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2496288242231744031
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4261264091733659315}
+  m_Mesh: {fileID: 4300040, guid: 0045ffb477e043a46950af7e617beb06, type: 3}
+--- !u!23 &8765320183250751633
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4261264091733659315}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a74066172cf19cd4bacae3c6600a7217, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/Assets/Prefabs/Monster.prefab.meta
+++ b/Assets/Prefabs/Monster.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4393c82978660c746b4ccc94f532a86e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Spawner.prefab
+++ b/Assets/Prefabs/Spawner.prefab
@@ -45,3 +45,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gizmoMesh: {fileID: 4300002, guid: 0045ffb477e043a46950af7e617beb06, type: 3}
+  startingSpawn: 1

--- a/Assets/Prefabs/Spawner.prefab
+++ b/Assets/Prefabs/Spawner.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4560637941449431342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5624982742449040542}
+  - component: {fileID: 2116749572386837614}
+  m_Layer: 0
+  m_Name: Spawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5624982742449040542
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4560637941449431342}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.88, y: 0.519, z: -3.11}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2116749572386837614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4560637941449431342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac935a605c074b84d9024594d901b1f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gizmoMesh: {fileID: 4300002, guid: 0045ffb477e043a46950af7e617beb06, type: 3}

--- a/Assets/Prefabs/Spawner.prefab.meta
+++ b/Assets/Prefabs/Spawner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 835f3c0d869144e4bba1a115d203de0e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -119,6 +119,145 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &84520485
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4560637941449431342, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_Name
+      value: Spawner (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.92967653
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.36837688
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 43.231
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+--- !u!1 &204669531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 204669533}
+  - component: {fileID: 204669532}
+  m_Layer: 0
+  m_Name: SpawnControl
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &204669532
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 204669531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e668b6700632d584c9a2d1f820a781b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyPrefab: {fileID: 4261264091733659315, guid: 4393c82978660c746b4ccc94f532a86e, type: 3}
+  spawnPoints: []
+  spawnCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0.015097618
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.16297786
+    - serializedVersion: 3
+      time: 0.5
+      value: 3
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.12925579
+    - serializedVersion: 3
+      time: 1
+      value: 0.021702034
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  enemiesToSpawnInRoom: 4
+  enemiesInRoomAtStart: 4
+  spawnRate: 0.7
+--- !u!4 &204669533
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 204669531}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &330585543
 GameObject:
   m_ObjectHideFlags: 0
@@ -1391,6 +1530,120 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34de14c5f4197634a889d99f3c3d216a, type: 3}
+--- !u!1001 &1894592094
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4560637941449431342, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_Name
+      value: Spawner (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.50000095
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.34737542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9377262
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -139.346
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+--- !u!1001 &3959545902249072584
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4560637941449431342, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_Name
+      value: Spawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.519
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9735255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.22857845
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -26.427
+      objectReference: {fileID: 0}
+    - target: {fileID: 5624982742449040542, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1402,3 +1655,7 @@ SceneRoots:
   - {fileID: 1891880639}
   - {fileID: 1440355341}
   - {fileID: 681810184}
+  - {fileID: 3959545902249072584}
+  - {fileID: 1894592094}
+  - {fileID: 84520485}
+  - {fileID: 204669533}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -206,7 +206,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemyPrefab: {fileID: 4261264091733659315, guid: 4393c82978660c746b4ccc94f532a86e, type: 3}
-  spawnPoints: []
   spawnCurve:
     serializedVersion: 2
     m_Curve:
@@ -240,9 +239,9 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  enemiesToSpawnInRoom: 4
-  enemiesInRoomAtStart: 4
-  spawnRate: 0.7
+  enemiesToSpawnInRoom: 20
+  enemiesInRoomAtStart: 2
+  spawnRate: 2
 --- !u!4 &204669533
 Transform:
   m_ObjectHideFlags: 0
@@ -527,6 +526,72 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 1
+--- !u!1001 &518822127
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1697641641}
+    m_Modifications:
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947190764797059366, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_Name
+      value: NorthDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8774339405929696555, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: doorDirection
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+--- !u!4 &518822128 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+  m_PrefabInstance: {fileID: 518822127}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &681810183
 GameObject:
   m_ObjectHideFlags: 0
@@ -613,6 +678,138 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 681810183}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &804317815
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1697641641}
+    m_Modifications:
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947190764797059366, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_Name
+      value: WestDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8774339405929696555, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: doorDirection
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+--- !u!4 &804317816 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+  m_PrefabInstance: {fileID: 804317815}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &831985926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1697641641}
+    m_Modifications:
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 270
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947190764797059366, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_Name
+      value: EastDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8774339405929696555, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: doorDirection
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+--- !u!4 &831985927 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+  m_PrefabInstance: {fileID: 831985926}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -1285,6 +1482,41 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1411525841}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1697641640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1697641641}
+  m_Layer: 0
+  m_Name: Doors
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1697641641
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697641640}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1646331145847093002}
+  - {fileID: 518822128}
+  - {fileID: 804317816}
+  - {fileID: 831985927}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1891880639
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1587,6 +1819,80 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 835f3c0d869144e4bba1a115d203de0e, type: 3}
+--- !u!1001 &1646331145847093001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1697641641}
+    m_Modifications:
+    - target: {fileID: 178196164183485560, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: startingSpawn
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947190764797059366, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: m_Name
+      value: SouthDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8774339405929696555, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: spawnDoor
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8774339405929696555, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+      propertyPath: doorDirection
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+--- !u!4 &1646331145847093002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6958219280195143855, guid: 8b3ace57969e67e4e99ca8e6d0acfedd, type: 3}
+  m_PrefabInstance: {fileID: 1646331145847093001}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3959545902249072584
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1659,3 +1965,4 @@ SceneRoots:
   - {fileID: 1894592094}
   - {fileID: 84520485}
   - {fileID: 204669533}
+  - {fileID: 1697641641}

--- a/Assets/Scripts/PlayerCombat/PlayerWeapon.cs
+++ b/Assets/Scripts/PlayerCombat/PlayerWeapon.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -47,7 +48,7 @@ namespace PlayerCombat
 
         private void IA_FireActionOnStarted(InputAction.CallbackContext obj)
         {
-            if (Time.time < _lastFire + stats.fireDelay && _canFire)
+            if (Time.time < _lastFire + stats.fireDelay && !_canFire)
                 _canFire = true;
             
             // if we're still waiting for a previous shot to cool down, we can't fire again
@@ -55,6 +56,12 @@ namespace PlayerCombat
             
             _isFiring = true;
             StartCoroutine(FiringRoutine());
+        }
+
+        private void OnDisable()
+        {
+            _canFire = false;
+            StopCoroutine(FiringRoutine());
         }
 
         private IEnumerator FiringRoutine()

--- a/Assets/Scripts/PlayerCombat/WeaponProjectilePool.cs
+++ b/Assets/Scripts/PlayerCombat/WeaponProjectilePool.cs
@@ -26,6 +26,12 @@ namespace PlayerCombat
             }
         }
 
+        private void OnDestroy()
+        {
+            if(_pool != null)
+                _pool.Clear();
+        }
+
         private void OnDestroyPoolObject(PlayerProjectile obj)
         {
             Destroy(obj);

--- a/Assets/Scripts/PlayerCombat/WeaponProjectilePool.cs
+++ b/Assets/Scripts/PlayerCombat/WeaponProjectilePool.cs
@@ -28,8 +28,7 @@ namespace PlayerCombat
 
         private void OnDestroy()
         {
-            if(_pool != null)
-                _pool.Clear();
+            _pool?.Clear();
         }
 
         private void OnDestroyPoolObject(PlayerProjectile obj)

--- a/Assets/Scripts/Rooms.meta
+++ b/Assets/Scripts/Rooms.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 491aa07e97607864daee32150652d196
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Rooms/RoomDoor.cs
+++ b/Assets/Scripts/Rooms/RoomDoor.cs
@@ -1,0 +1,66 @@
+using System;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace Rooms
+{
+    public enum DoorDirection
+    {
+        North,
+        South,
+        East,
+        West
+    }
+    public class RoomDoor : MonoBehaviour
+    {
+        private SpawnPoint _spawnComponent;
+        [SerializeField] private Transform spawnTransform;
+        [SerializeField] private DoorDirection doorDirection;
+        private bool _isLocked = true;
+        [SerializeField] private bool spawnDoor = false;
+
+        [SerializeField] private Mesh lockedMesh;
+        [SerializeField] private Mesh openMesh;
+        //[SerializeField] private Mesh closedMesh;
+        
+        private MeshFilter _meshFilter;
+        public bool IsSpawnDoor => spawnDoor;
+
+        private void Start()
+        {
+            _spawnComponent = GetComponent<SpawnPoint>();
+            _meshFilter = GetComponent<MeshFilter>();
+            Debug.Assert(_spawnComponent != null);
+            Debug.Assert(_meshFilter != null);
+            
+            _spawnComponent.SetSpawnPositionAndRotation(spawnTransform.position, spawnTransform.rotation);
+        }
+        
+        private void OnTriggerEnter(Collider other)
+        {
+            if (_isLocked) return;
+
+            if (other.CompareTag("Player"))
+            {
+                Debug.Log("Transition outta here");
+            }
+        }
+
+        public void MakeSpawnDoor()
+        {
+            spawnDoor = true;
+            
+            // spawn doors remain closed as the player cannot go "back" on themselves
+            // so we show a "locked mesh".
+            _meshFilter.mesh = lockedMesh;
+        }
+        
+        public void Unlock()
+        {
+            _isLocked = false;
+
+            _meshFilter.mesh = openMesh;
+        }
+    }
+
+}

--- a/Assets/Scripts/Rooms/RoomDoor.cs.meta
+++ b/Assets/Scripts/Rooms/RoomDoor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25c12336356bddc48a9f697c2665923b

--- a/Assets/Scripts/Rooms/SpawnController.cs
+++ b/Assets/Scripts/Rooms/SpawnController.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections;
+using System.Linq;
+using Unity.VisualScripting;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace Rooms
+{
+    public class SpawnController : MonoBehaviour
+    {
+        [SerializeField] private GameObject enemyPrefab;
+        [SerializeField] private SpawnPoint[] spawnPoints;
+        private int _spawnCount = 0;
+        public AnimationCurve spawnCurve;
+        [SerializeField] private int enemiesToSpawnInRoom;
+        [SerializeField] private int enemiesInRoomAtStart;
+        [SerializeField] private float spawnRate = 0.7f;
+        private WaitForSeconds _coroutineWait;
+        
+        private void Awake()
+        {
+            spawnPoints = FindObjectsByType<SpawnPoint>(FindObjectsSortMode.InstanceID);
+            
+            Debug.Assert(spawnPoints.Length > 0, "No SpawnPoints found in room prefab.");
+            
+            if (spawnPoints.Length < enemiesInRoomAtStart) enemiesInRoomAtStart = spawnPoints.Length;
+        }
+        
+        private void Start()
+        {
+            
+            
+            _coroutineWait = new WaitForSeconds(spawnRate);
+            StartCoroutine(SpawnEnemies());
+        }
+
+        private void OnEnable()
+        {
+            if(enemyPrefab == null) return;
+            
+            // select from the total spawn points and instantiate beasties.
+            SpawnPoint[] toSpawn = spawnPoints.OrderByDescending(point => point.ID)
+                                                .Take(enemiesInRoomAtStart)
+                                                .ToArray();
+
+            Debug.Log("toSpawn size:" + toSpawn.Length);
+            
+            foreach (var spawn in toSpawn)
+            {
+                spawn.SpawnObject(enemyPrefab);
+            }
+            
+            _spawnCount = enemiesInRoomAtStart;
+        }
+
+        private void OnDisable()
+        {
+            StopCoroutine(SpawnEnemies());
+        }
+
+        private IEnumerator SpawnEnemies()
+        {
+            while (true)
+            {
+                yield return _coroutineWait;
+
+                if (_spawnCount >= enemiesToSpawnInRoom) break;
+                
+                
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Rooms/SpawnController.cs
+++ b/Assets/Scripts/Rooms/SpawnController.cs
@@ -10,48 +10,59 @@ namespace Rooms
     public class SpawnController : MonoBehaviour
     {
         [SerializeField] private GameObject enemyPrefab;
-        [SerializeField] private SpawnPoint[] spawnPoints;
+        private SpawnPoint[] _startPoints;
+        private SpawnPoint[] _validDoors;
+        private SpawnPoint[] _spawnPoints;
         private int _spawnCount = 0;
         public AnimationCurve spawnCurve;
         [SerializeField] private int enemiesToSpawnInRoom;
         [SerializeField] private int enemiesInRoomAtStart;
-        [SerializeField] private float spawnRate = 0.7f;
+        [SerializeField] private float spawnRate = 2.0f;
         private WaitForSeconds _coroutineWait;
+        
         
         private void Awake()
         {
-            spawnPoints = FindObjectsByType<SpawnPoint>(FindObjectsSortMode.InstanceID);
+            _spawnPoints = FindObjectsByType<SpawnPoint>(FindObjectsSortMode.InstanceID);
             
-            Debug.Assert(spawnPoints.Length > 0, "No SpawnPoints found in room prefab.");
+            Debug.Assert(_spawnPoints.Length > 0, "No SpawnPoints found in room prefab.");
             
-            if (spawnPoints.Length < enemiesInRoomAtStart) enemiesInRoomAtStart = spawnPoints.Length;
+            if (_spawnPoints.Length < enemiesInRoomAtStart) enemiesInRoomAtStart = _spawnPoints.Length;
+            
+            /*
+             * This uses LINQ methods to find the spawn points flagged as starting spawns
+             * sorted by their unique ID and then only use the number of spawns set in enemiesInRoomAtStart
+             * https://learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/
+             */
+            _startPoints = _spawnPoints.Where(point => point.IsStartingSpawn)
+                .OrderByDescending(point => point.ID)
+                .Take(enemiesInRoomAtStart)
+                .ToArray();
+            
+            // find all the door spawn points to use during play
+            _validDoors = _spawnPoints.Where(point => point.IsStartingSpawn == false)
+                .Where(point => point.GetComponent<RoomDoor>().IsSpawnDoor == false)
+                .ToArray();
+
+            // adjust the curve keys to adjust for the maximum number of enemies to spawn
+            spawnCurve.MoveKey(2, new Keyframe(enemiesToSpawnInRoom, 0.0f));
+            spawnCurve.MoveKey(1, new Keyframe(enemiesToSpawnInRoom / 2.0f, 3.0f));
         }
         
         private void Start()
         {
-            
-            
-            _coroutineWait = new WaitForSeconds(spawnRate);
-            StartCoroutine(SpawnEnemies());
-        }
-
-        private void OnEnable()
-        {
             if(enemyPrefab == null) return;
             
-            // select from the total spawn points and instantiate beasties.
-            SpawnPoint[] toSpawn = spawnPoints.OrderByDescending(point => point.ID)
-                                                .Take(enemiesInRoomAtStart)
-                                                .ToArray();
-
-            Debug.Log("toSpawn size:" + toSpawn.Length);
-            
-            foreach (var spawn in toSpawn)
+            foreach (var spawn in _startPoints)
             {
                 spawn.SpawnObject(enemyPrefab);
             }
             
-            _spawnCount = enemiesInRoomAtStart;
+            if(_startPoints.Length > 0)
+                _spawnCount = enemiesInRoomAtStart;
+            
+            _coroutineWait = new WaitForSeconds(spawnRate);
+            StartCoroutine(SpawnEnemies());
         }
 
         private void OnDisable()
@@ -66,7 +77,23 @@ namespace Rooms
                 yield return _coroutineWait;
 
                 if (_spawnCount >= enemiesToSpawnInRoom) break;
-                
+
+                // the animation curve gives us a float value based on the "time" we pass
+                // in to evaluate; here our time is actually how many enemies have already spawned
+                // the number we get back is how many enemies we should spawn.
+                int numberToSpawn = (int)Mathf.Ceil(spawnCurve.Evaluate(_spawnCount));
+                Debug.Log("number of enemies to spawn: " + numberToSpawn);
+                int startDoor = Random.Range(0, _validDoors.Length);
+
+                for (int i = 0; i < numberToSpawn; i++)
+                {
+                    SpawnPoint door = _validDoors[startDoor];
+                    door.SpawnObject(enemyPrefab);
+                    _spawnCount++;
+                    startDoor++;
+                    if (startDoor == _validDoors.Length)
+                        startDoor = 0;
+                }
                 
             }
         }

--- a/Assets/Scripts/Rooms/SpawnController.cs.meta
+++ b/Assets/Scripts/Rooms/SpawnController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e668b6700632d584c9a2d1f820a781b3

--- a/Assets/Scripts/Rooms/SpawnPoint.cs
+++ b/Assets/Scripts/Rooms/SpawnPoint.cs
@@ -7,12 +7,43 @@ namespace Rooms
     public class SpawnPoint : MonoBehaviour
     {
         [SerializeField] private Mesh gizmoMesh;
+        [SerializeField] private bool startingSpawn = true;
+        private Vector3 _spawnPosition;
+        private Quaternion _spawnRotation;
         private const float YOffset = 0.5f;
-
+        
+        // to allow these to be sorted, we get a GUID (Globally Unique ID) for each spawn point component
+        // because we cannot guarantee the order of Awake or Start, we have to initialise it here.
+        // Formally, we are using a property here to ensure the ID cannot be changed once initialised
+        // we can't use const as Guid.NewGuid does not return a value at compile time.
         public Guid ID { get; } = Guid.NewGuid();
+        public bool IsStartingSpawn => startingSpawn;
 
+        private void Awake()
+        {
+            _spawnPosition = transform.position;
+            _spawnRotation = transform.rotation;
+        }
+
+        /*
+         * Allow for the spawn position and rotation to be overridden
+         * Used by RoomDoor to shift the spawn point away from the door origin
+         */
+        public void SetSpawnPositionAndRotation(Vector3 pos, Quaternion rot)
+        {
+            _spawnPosition = pos;
+            _spawnRotation = rot;
+        }
+        
+        /*
+         * SpawnPoints do not have a physical representation, which is what we want in the game
+         * in the editor, we want to see where they are and interact with them, so we draw a mesh gizmo
+         * to give us that representation.
+         */
         private void OnDrawGizmos()
         {
+            if (gizmoMesh == null) return;
+            
             Gizmos.color = Color.red;
             Gizmos.DrawWireMesh(gizmoMesh, transform.position, transform.rotation);
         }
@@ -20,8 +51,8 @@ namespace Rooms
         public void SpawnObject(GameObject prefab)
         {
             Vector3 spawnPosition =
-                new Vector3(transform.position.x, transform.position.y + YOffset, transform.position.z);
-            Instantiate(prefab, spawnPosition, transform.rotation);
+                new Vector3(_spawnPosition.x, _spawnPosition.y + YOffset, _spawnPosition.z);
+            Instantiate(prefab, spawnPosition, _spawnRotation);
         }
     }
 }

--- a/Assets/Scripts/Rooms/SpawnPoint.cs
+++ b/Assets/Scripts/Rooms/SpawnPoint.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace Rooms
+{
+    public class SpawnPoint : MonoBehaviour
+    {
+        [SerializeField] private Mesh gizmoMesh;
+        private const float YOffset = 0.5f;
+
+        public Guid ID { get; } = Guid.NewGuid();
+
+        private void OnDrawGizmos()
+        {
+            Gizmos.color = Color.red;
+            Gizmos.DrawWireMesh(gizmoMesh, transform.position, transform.rotation);
+        }
+
+        public void SpawnObject(GameObject prefab)
+        {
+            Vector3 spawnPosition =
+                new Vector3(transform.position.x, transform.position.y + YOffset, transform.position.z);
+            Instantiate(prefab, spawnPosition, transform.rotation);
+        }
+    }
+}

--- a/Assets/Scripts/Rooms/SpawnPoint.cs.meta
+++ b/Assets/Scripts/Rooms/SpawnPoint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ac935a605c074b84d9024594d901b1f9


### PR DESCRIPTION
Implemented monster spawning logic (see Scripts/Rooms)

There are two "waves" of spawning; as the room is entered and during gameplay

SpawnPoints flagged as "startingSpawn" are used for the former.
SpawnPoints associated with RoomDoor components are for the latter.

RoomDoor represents a game object that is either an entry point into the room or one of the exits and monster spawns.

SpawnController.cs manages the core logic; it finds all objects of type SpawnPoint and separates them based on the above rules.